### PR TITLE
feat: release please with publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1.6.0
+    

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,30 @@
+# This workflow opens and updates a pull request with a new package version
+# based on code changes.
+
+# The pull request updates the version in pubspec.yaml, updates the changelog and creates release tags.
+
+# For more information, see https://github.com/marketplace/actions/release-please-action
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: google-github-actions/release-please-action@v3.7.10
+        with:
+          release-type: dart
+          package-name: release-please-action
+          pull-request-title-pattern: 'chore(release): ${version}'
+          pull-request-header: ':robot: Merge this PR to release a new version'
+          extra-files: |
+            README.md


### PR DESCRIPTION
Release-As: 2.0.1

Adding _release-please_ workflow to release a new version SDK and _publish_ workflow to publish SDK to the pub.dev. 

Because of: 

> info Note: Pub.dev only allows automated publishing from GitHub Actions when the workflow is triggered by pushing a git tag to GitHub. Pub.dev rejects publishing from GitHub Actions triggered without a tag. This ensures that new versions cannot be published by events that should never trigger publishing.

see https://dart.dev/tools/pub/automated-publishing#publishing-packages-using-github-actions

I had to set trigger for publish workflow on new tags not on master like it's done in other SDKs. 

- [x] ⚠️ Before merge: we need to setup automatic publish in pub.dev - https://dart.dev/tools/pub/automated-publishing#configuring-automated-publishing-from-github-actions-on-pubdev

Release test PR: https://github.com/vlnevyhosteny/buttercms-dart/pull/3